### PR TITLE
[Android][히데] 마일스톤 페이지, 마일스톤 작성페이지 UI 완성

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
+    id 'kotlin-kapt'
 }
 
 android {

--- a/Android/app/src/main/java/com/example/issue_tracker/MainActivity.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/MainActivity.kt
@@ -1,7 +1,7 @@
 package com.example.issue_tracker
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.get
 import androidx.core.view.isVisible
 import androidx.databinding.DataBindingUtil
@@ -15,7 +15,7 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = DataBindingUtil.setContentView(this, R.layout.activity_main)
-        binding.lifecycleOwner= this
+        binding.lifecycleOwner = this
         setContentView(binding.root)
         setupNav()
     }
@@ -30,7 +30,7 @@ class MainActivity : AppCompatActivity() {
 
         navController?.addOnDestinationChangedListener { _, destination, _ ->
             when (destination.id) {
-              //  R.id.issueWriteFragment -> binding.bottomNavigationView.menu[0].isChecked=true
+                R.id.mileStoneWriteFragment -> binding.bottomNavigationView.menu[2].isChecked = true
             }
         }
     }

--- a/Android/app/src/main/java/com/example/issue_tracker/domain/model/MileStone.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/domain/model/MileStone.kt
@@ -1,0 +1,10 @@
+package com.example.issue_tracker.domain.model
+
+data class MileStone(
+    val id:Int,
+    val title: String,
+    val content: String,
+    val completeDay: String,
+    val openIssueCount: Int,
+    val closeIssueCount: Int
+)

--- a/Android/app/src/main/java/com/example/issue_tracker/domain/model/MileStone.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/domain/model/MileStone.kt
@@ -1,7 +1,7 @@
 package com.example.issue_tracker.domain.model
 
 data class MileStone(
-    val id:Int,
+    val id: Int,
     val title: String,
     val content: String,
     val completeDay: String,

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/common/MileStoneBindingAdapter.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/common/MileStoneBindingAdapter.kt
@@ -6,7 +6,7 @@ import com.example.issue_tracker.R
 
 @BindingAdapter("totalCount", "finishCount")
 fun calculateProgress(view: TextView, totalCount: Int, finishCount: Int) {
-    val progress = (100/(totalCount / finishCount))
+    val progress = (100 / (totalCount / finishCount))
     view.text = view.context.getString(R.string.milestone_item_progress, progress)
 }
 

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/common/MileStoneBindingAdapter.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/common/MileStoneBindingAdapter.kt
@@ -1,0 +1,21 @@
+package com.example.issue_tracker.ui.common
+
+import android.widget.TextView
+import androidx.databinding.BindingAdapter
+import com.example.issue_tracker.R
+
+@BindingAdapter("totalCount", "finishCount")
+fun calculateProgress(view: TextView, totalCount: Int, finishCount: Int) {
+    val progress = (100/(totalCount / finishCount))
+    view.text = view.context.getString(R.string.milestone_item_progress, progress)
+}
+
+@BindingAdapter("opeIssueCount")
+fun setOpenIssueCount(view: TextView, openIssueCount: Int) {
+    view.text = view.context.getString(R.string.milestone_item_open_issue_count, openIssueCount)
+}
+
+@BindingAdapter("closedIssueCount")
+fun setClosedIssueCount(view: TextView, closedIssueCount: Int) {
+    view.text = view.context.getString(R.string.milestone_item_open_issue_count, closedIssueCount)
+}

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/login/LogInActivity.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/login/LogInActivity.kt
@@ -1,7 +1,7 @@
 package com.example.issue_tracker.ui.login
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 import com.example.issue_tracker.R
 
 class LogInActivity : AppCompatActivity() {

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/milestone/MileStoneAdapter.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/milestone/MileStoneAdapter.kt
@@ -10,33 +10,33 @@ import com.example.issue_tracker.databinding.ItemMilestoneBinding
 import com.example.issue_tracker.domain.model.MileStone
 
 
-class MilestoneAdapter()  : ListAdapter<MileStone, MilestoneAdapter.ViewHolder>(MilestoneDiffUtil) {
+class MilestoneAdapter() : ListAdapter<MileStone, MilestoneAdapter.ViewHolder>(MilestoneDiffUtil) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val inflater = LayoutInflater.from(parent.context)
         return ViewHolder(ItemMilestoneBinding.inflate(inflater, parent, false))
     }
 
-    override fun onBindViewHolder(holder:MilestoneAdapter.ViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: MilestoneAdapter.ViewHolder, position: Int) {
         holder.bind(getItem(position))
     }
 
     class ViewHolder(private val binding: ItemMilestoneBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(item:MileStone) {
-            binding.milestone= item
-            binding.totalCount= item.closeIssueCount+ item.openIssueCount
+        fun bind(item: MileStone) {
+            binding.milestone = item
+            binding.totalCount = item.closeIssueCount + item.openIssueCount
         }
     }
 
     companion object MilestoneDiffUtil : DiffUtil.ItemCallback<MileStone>() {
         override fun areItemsTheSame(oldItem: MileStone, newItem: MileStone): Boolean {
-            return oldItem.id==newItem.id
+            return oldItem.id == newItem.id
         }
 
         override fun areContentsTheSame(oldItem: MileStone, newItem: MileStone): Boolean {
-            return oldItem==newItem
+            return oldItem == newItem
         }
 
     }

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/milestone/MileStoneAdapter.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/milestone/MileStoneAdapter.kt
@@ -1,0 +1,43 @@
+package com.example.issue_tracker.ui.milestone
+
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.example.issue_tracker.databinding.ItemMilestoneBinding
+import com.example.issue_tracker.domain.model.MileStone
+
+
+class MilestoneAdapter()  : ListAdapter<MileStone, MilestoneAdapter.ViewHolder>(MilestoneDiffUtil) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        return ViewHolder(ItemMilestoneBinding.inflate(inflater, parent, false))
+    }
+
+    override fun onBindViewHolder(holder:MilestoneAdapter.ViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class ViewHolder(private val binding: ItemMilestoneBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(item:MileStone) {
+            binding.milestone= item
+            binding.totalCount= item.closeIssueCount+ item.openIssueCount
+        }
+    }
+
+    companion object MilestoneDiffUtil : DiffUtil.ItemCallback<MileStone>() {
+        override fun areItemsTheSame(oldItem: MileStone, newItem: MileStone): Boolean {
+            return oldItem.id==newItem.id
+        }
+
+        override fun areContentsTheSame(oldItem: MileStone, newItem: MileStone): Boolean {
+            return oldItem==newItem
+        }
+
+    }
+}

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/milestone/MileStoneFragment.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/milestone/MileStoneFragment.kt
@@ -5,56 +5,38 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
 import com.example.issue_tracker.R
+import com.example.issue_tracker.databinding.FragmentMileStoneBinding
+import com.example.issue_tracker.domain.model.MileStone
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-private const val ARG_PARAM1 = "param1"
-private const val ARG_PARAM2 = "param2"
 
-/**
- * A simple [Fragment] subclass.
- * Use the [MileStoneFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
 class MileStoneFragment : Fragment() {
-    // TODO: Rename and change types of parameters
-    private var param1: String? = null
-    private var param2: String? = null
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        arguments?.let {
-            param1 = it.getString(ARG_PARAM1)
-            param2 = it.getString(ARG_PARAM2)
-        }
-    }
-
+    private lateinit var binding:FragmentMileStoneBinding
+    private lateinit var adapter: MilestoneAdapter
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_mile_stone, container, false)
+        binding= DataBindingUtil.inflate(inflater, R.layout.fragment_mile_stone, container, false)
+        return binding.root
     }
 
-    companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment MileStoneFragment.
-         */
-        // TODO: Rename and change types and number of parameters
-        @JvmStatic
-        fun newInstance(param1: String, param2: String) =
-            MileStoneFragment().apply {
-                arguments = Bundle().apply {
-                    putString(ARG_PARAM1, param1)
-                    putString(ARG_PARAM2, param2)
-                }
-            }
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        adapter= MilestoneAdapter()
+        binding.rvMilestone.adapter= adapter
+        adapter.submitList(makeDummyMileStones())
+
+    }
+
+
+    private fun makeDummyMileStones(): MutableList<MileStone> {
+        val milestones = mutableListOf<MileStone>()
+        for(i in 0..10){
+            milestones.add(MileStone(i,"마일스톤 제목${i}", "마일스톤 더미 콘테츠", "06-14", 2,2))
+        }
+        return milestones
     }
 }

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/milestone/MileStoneFragment.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/milestone/MileStoneFragment.kt
@@ -1,11 +1,13 @@
 package com.example.issue_tracker.ui.milestone
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.Fragment
+import androidx.navigation.NavController
+import androidx.navigation.Navigation
 import com.example.issue_tracker.R
 import com.example.issue_tracker.databinding.FragmentMileStoneBinding
 import com.example.issue_tracker.domain.model.MileStone
@@ -13,29 +15,40 @@ import com.example.issue_tracker.domain.model.MileStone
 
 class MileStoneFragment : Fragment() {
 
-    private lateinit var binding:FragmentMileStoneBinding
+    private lateinit var binding: FragmentMileStoneBinding
     private lateinit var adapter: MilestoneAdapter
+    private lateinit var navigator: NavController
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding= DataBindingUtil.inflate(inflater, R.layout.fragment_mile_stone, container, false)
+        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_mile_stone, container, false)
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        adapter= MilestoneAdapter()
-        binding.rvMilestone.adapter= adapter
+        adapter = MilestoneAdapter()
+        navigator = Navigation.findNavController(view)
+        var window = requireActivity().window
+
+        //window.statusBarColor= ContextCompat.getColor(requireContext(), R.color.skyBlue)
+        binding.iBtnMilestoneAdd.setOnClickListener {
+            moveToAddMileStone()
+        }
+        binding.rvMilestone.adapter = adapter
         adapter.submitList(makeDummyMileStones())
 
     }
 
+    private fun moveToAddMileStone() {
+        navigator.navigate(R.id.action_navigation_milestone_to_mileStoneWriteFragment)
+    }
 
     private fun makeDummyMileStones(): MutableList<MileStone> {
         val milestones = mutableListOf<MileStone>()
-        for(i in 0..10){
-            milestones.add(MileStone(i,"마일스톤 제목${i}", "마일스톤 더미 콘테츠", "06-14", 2,2))
+        for (i in 0..10) {
+            milestones.add(MileStone(i, "마일스톤 제목${i}", "마일스톤 더미 콘테츠", "06-14", 2, 2))
         }
         return milestones
     }

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/milestone/MileStoneWriteFragment.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/milestone/MileStoneWriteFragment.kt
@@ -1,0 +1,141 @@
+package com.example.issue_tracker.ui.milestone
+
+import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.Fragment
+import androidx.navigation.NavController
+import androidx.navigation.Navigation
+import com.example.issue_tracker.R
+import com.example.issue_tracker.databinding.FragmentMileStoneWriteBinding
+import java.text.SimpleDateFormat
+
+class MileStoneWriteFragment : Fragment() {
+    private lateinit var binding: FragmentMileStoneWriteBinding
+    private lateinit var navigator: NavController
+    private var completeDayFlag: Boolean = true
+    private var titleFlag: Boolean = false
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_mile_stone_write, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        changeStatusBarColor()
+        setUpBackButton()
+        setSaveMilestoneBtn()
+        validateCompleteDayFormat()
+        validateMileStoneTitle()
+        navigator = Navigation.findNavController(view)
+    }
+
+    private fun changeStatusBarColor() {
+        requireActivity().window.statusBarColor =
+            ContextCompat.getColor(requireContext(), R.color.skyBlue)
+    }
+
+    private fun validateCompleteDayFormat() {
+        binding.etMilestoneWriteCompleteDay.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+
+            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+
+            override fun afterTextChanged(inputDate: Editable?) {
+                try {
+                    val dateFormatter = SimpleDateFormat("yyyy-MM-dd")
+                    dateFormatter.isLenient = true
+                    dateFormatter.parse(inputDate.toString())
+                    completeDayFlag = true
+                } catch (e: Exception) {
+                    binding.etMilestoneWriteCompleteDay.error =
+                        getString(R.string.milestone_write_compleday_error)
+                    completeDayFlag = false
+                } finally {
+                    setCompleteDayLabelBackground()
+                }
+            }
+        }
+        )
+    }
+
+    private fun validateMileStoneTitle() {
+        binding.etMilestoneWriteTitle.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+
+            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+
+            override fun afterTextChanged(inputTitle: Editable?) {
+                val title = inputTitle.toString()
+                titleFlag = title.isNotEmpty()
+                setSaveTitleColor()
+            }
+        }
+        )
+    }
+
+    private fun setSaveMilestoneBtn() {
+        binding.tvMilestoneWriteSaveTitle.setOnClickListener {
+            if (titleFlag) {
+                //To DO: save MileStone
+            }
+        }
+    }
+
+    private fun setSaveTitleColor() {
+        if (titleFlag) {
+            binding.tvMilestoneWriteSaveTitle.setTextColor(
+                ContextCompat.getColor(
+                    requireContext(),
+                    R.color.white
+                )
+            )
+        } else {
+            binding.etMilestoneWriteTitle.error = "필수입력값입니다"
+            binding.tvMilestoneWriteSaveTitle.setTextColor(
+                ContextCompat.getColor(
+                    requireContext(),
+                    R.color.grey1
+                )
+            )
+        }
+    }
+
+    private fun setCompleteDayLabelBackground() {
+        if (completeDayFlag) {
+            binding.tvMilestoneWriteContentCompleteDay.setTextColor(
+                ContextCompat.getColor(
+                    requireContext(),
+                    R.color.black
+                )
+            )
+        } else {
+            binding.tvMilestoneWriteContentCompleteDay.setTextColor(
+                ContextCompat.getColor(
+                    requireContext(),
+                    R.color.red
+                )
+            )
+        }
+    }
+
+    private fun setUpBackButton() {
+        binding.iBtnMilestoneWriteBack.setOnClickListener {
+            navigator.navigateUp()
+        }
+    }
+
+    override fun onStop() {
+        super.onStop()
+        requireActivity().window.statusBarColor =
+            ContextCompat.getColor(requireContext(), R.color.white)
+    }
+}

--- a/Android/app/src/main/res/color/tab_selector_color.xml
+++ b/Android/app/src/main/res/color/tab_selector_color.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:color="@color/skyBlue" android:state_selected="true"/>
+    <item android:color="@color/grey1"/>
+</selector>

--- a/Android/app/src/main/res/drawable/btn_blue_radius.xml
+++ b/Android/app/src/main/res/drawable/btn_blue_radius.xml
@@ -2,8 +2,9 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
 
-    <solid android:color="@color/black"/>
+    <solid android:color="@color/blue3"/>
 
+    <stroke android:width="1dp" android:color="@color/blue1" />
     <corners android:radius="60px"/>
 
 </shape>

--- a/Android/app/src/main/res/drawable/btn_skyblue_radius.xml
+++ b/Android/app/src/main/res/drawable/btn_skyblue_radius.xml
@@ -2,8 +2,9 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
 
-    <solid android:color="@color/black"/>
+    <solid android:color="@color/selected_skyBlue"/>
 
+    <stroke android:width="1dp" android:color="@color/blue2" />
     <corners android:radius="60px"/>
 
 </shape>

--- a/Android/app/src/main/res/drawable/ic_back_white.xml
+++ b/Android/app/src/main/res/drawable/ic_back_white.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="12dp"
+    android:height="20dp"
+    android:viewportWidth="12"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M10,20L0,10L10,0L11.775,1.775L3.55,10L11.775,18.225L10,20Z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/Android/app/src/main/res/drawable/ic_calendar_grey.xml
+++ b/Android/app/src/main/res/drawable/ic_calendar_grey.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="14dp"
+    android:height="16dp"
+    android:viewportWidth="14"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M0.25,15.5V2H2.5V0.5H4V2H10V0.5H11.5V2H13.75V15.5H0.25ZM1.75,14H12.25V6.5H1.75V14ZM1.75,5H12.25V3.5H1.75V5ZM1.75,5V3.5V5Z"
+      android:fillColor="#8E8E93"/>
+</vector>

--- a/Android/app/src/main/res/drawable/ic_close_blue.xml
+++ b/Android/app/src/main/res/drawable/ic_close_blue.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="14dp"
+    android:height="14dp"
+    android:viewportWidth="14"
+    android:viewportHeight="14">
+  <path
+      android:pathData="M1.0002,13.6667V4.8H0.3335V0.3333H13.6668V4.8H13.0002V13.6667H1.0002ZM2.3335,12.3333H11.6668V5H2.3335V12.3333ZM1.6668,3.6667H12.3335V1.6667H1.6668V3.6667ZM5.0002,8.3333H9.0002V7H5.0002V8.3333ZM2.3335,12.3333V5V12.3333Z"
+      android:fillColor="#0025E7"/>
+</vector>

--- a/Android/app/src/main/res/drawable/ic_issue_blue.xml
+++ b/Android/app/src/main/res/drawable/ic_issue_blue.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/blue2">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M11,15h2v2h-2zM11,7h2v6h-2zM11.99,2C6.47,2 2,6.48 2,12s4.47,10 9.99,10C17.52,22 22,17.52 22,12S17.52,2 11.99,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8z"/>
+</vector>

--- a/Android/app/src/main/res/drawable/ic_plus_skyblue.xml
+++ b/Android/app/src/main/res/drawable/ic_plus_skyblue.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="15dp"
+    android:height="14dp"
+    android:viewportWidth="15"
+    android:viewportHeight="14">
+  <path
+      android:pathData="M14.5,8H8.5V14H6.5V8H0.5V6H6.5V0H8.5V6H14.5V8Z"
+      android:fillColor="#007AFF"
+      android:fillType="evenOdd"/>
+</vector>

--- a/Android/app/src/main/res/layout/activity_main.xml
+++ b/Android/app/src/main/res/layout/activity_main.xml
@@ -29,6 +29,9 @@
             android:id="@+id/bottom_navigation_view"
             android:layout_width="match_parent"
             app:menu="@menu/bottom_nav"
+            app:itemIconTint="@color/tab_selector_color"
+            app:itemTextColor="@color/tab_selector_color"
+            app:labelVisibilityMode="labeled"
             app:layout_constraintBottom_toBottomOf="parent"
             android:layout_height="wrap_content"/>
 

--- a/Android/app/src/main/res/layout/fragment_mile_stone.xml
+++ b/Android/app/src/main/res/layout/fragment_mile_stone.xml
@@ -1,14 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".ui.milestone.MileStoneFragment">
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <!-- TODO: Update blank fragment layout -->
-    <TextView
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:text="Mile Stone" />
+        android:paddingHorizontal="16dp"
+        tools:context=".ui.milestone.MileStoneFragment">
 
-</FrameLayout>
+        <TextView
+            android:id="@+id/tv_milestone_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingVertical="16dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            style="@style/HeadLine6.Black.Bold"
+            android:text="마일스톤" />
+
+        <ImageButton
+            android:id="@+id/iBtn_milestone_add"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@drawable/ic_plus_skyblue"
+            app:layout_constraintTop_toTopOf="@id/tv_milestone_title"
+            app:layout_constraintBottom_toBottomOf="@id/tv_milestone_title"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:layout_width="match_parent"
+            android:id="@+id/rv_milestone"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toBottomOf="@id/tv_milestone_title"
+            app:layout_constraintBottom_toBottomOf="parent"
+            android:orientation="vertical"
+            tools:listitem="@layout/item_milestone"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/Android/app/src/main/res/layout/fragment_mile_stone_write.xml
+++ b/Android/app/src/main/res/layout/fragment_mile_stone_write.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".ui.milestone.MileStoneWriteFragment">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/tb_milestone_write"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/skyBlue"
+            android:paddingTop="32dp"
+            android:paddingBottom="16dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageButton
+                android:id="@+id/iBtn_milestone_write_back"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@color/skyBlue"
+                android:src="@drawable/ic_back_white" />
+
+            <TextView
+                android:id="@+id/tv_milestone_write_title"
+                style="@style/HeadLine6.White"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="36dp"
+                android:text="@string/milestone_write_title" />
+
+            <TextView
+                android:id="@+id/tv_milestone_write_save_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:layout_marginEnd="16dp"
+                android:text="@string/milestone_write_save_title" />
+
+        </androidx.appcompat.widget.Toolbar>
+
+        <TextView
+            android:id="@+id/tv_milestone_write_content_title"
+            style="@style/Subtitle1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="20dp"
+            android:paddingVertical="16dp"
+            android:text="@string/milestone_write_title_title"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tb_milestone_write" />
+
+        <EditText
+            style="@style/Subtitle1"
+            android:id="@+id/et_milestone_write_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:background="@android:color/transparent"
+            android:hint="@string/milestone_write_title_hint"
+            android:paddingHorizontal="8dp"
+            android:paddingVertical="16dp"
+            app:layout_constraintBottom_toBottomOf="@id/tv_milestone_write_content_title"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/tv_milestone_write_content_title"
+            app:layout_constraintTop_toTopOf="@id/tv_milestone_write_content_title"
+            android:inputType="text" />
+
+        <TextView
+            android:id="@+id/tv_milestone_write_content"
+            style="@style/Subtitle1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="20dp"
+            android:paddingVertical="16dp"
+            android:text="@string/milestone_write_content_title"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_milestone_write_content_title" />
+
+        <EditText
+            style="@style/Subtitle1"
+            android:id="@+id/et_milestone_write_content"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:background="@android:color/transparent"
+            android:hint="@string/milestone_write_content_hint"
+            android:paddingHorizontal="8dp"
+            android:paddingVertical="16dp"
+            app:layout_constraintBottom_toBottomOf="@id/tv_milestone_write_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/tv_milestone_write_content"
+            app:layout_constraintTop_toTopOf="@id/tv_milestone_write_content"
+            android:inputType="text" />
+
+        <TextView
+            android:id="@+id/tv_milestone_write_content_complete_day"
+            style="@style/Subtitle1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:paddingStart="16dp"
+            android:paddingVertical="16dp"
+            android:text="@string/milestone_write_complete_day_title"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/tv_milestone_write_content_title"
+            app:layout_constraintTop_toBottomOf="@id/tv_milestone_write_content" />
+
+        <EditText
+            android:id="@+id/et_milestone_write_complete_day"
+            style="@style/Subtitle1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:background="@android:color/transparent"
+            android:hint="@string/milestone_write_complete_day_hint"
+            android:paddingHorizontal="8dp"
+            android:paddingVertical="16dp"
+            app:layout_constraintBottom_toBottomOf="@id/tv_milestone_write_content_complete_day"
+            android:maxLength="10"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/tv_milestone_write_content_complete_day"
+            app:layout_constraintTop_toTopOf="@id/tv_milestone_write_content_complete_day"
+            android:inputType="date" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            app:layout_constraintTop_toBottomOf="@id/tv_milestone_write_content_complete_day"
+            android:layout_marginVertical="16dp"
+            android:background="@color/grey5" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/Android/app/src/main/res/layout/item_milestone.xml
+++ b/Android/app/src/main/res/layout/item_milestone.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <variable
+            name="milestone"
+            type="com.example.issue_tracker.domain.model.MileStone" />
+
+        <variable
+            name="totalCount"
+            type="Integer" />
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_marginTop="16dp"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/tv_milestone_item_title"
+            style="@style/Subtitle1.Black.Bold"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@{milestone.title}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_milestone_item_progress"
+            style="@style/Subtitle1.Green.Bold"
+            finishCount="@{milestone.closeIssueCount}"
+            totalCount="@{totalCount}"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/label_milestone_item_progress"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_milestone_item_content"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:maxLines="1"
+            android:text="@{milestone.content}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_milestone_item_title" />
+
+        <TextView
+            android:id="@+id/tv_milestone_item_complete_day"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:drawableStart="@drawable/ic_calendar_grey"
+            android:drawablePadding="8dp"
+            android:text="@{milestone.completeDay}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_milestone_item_content" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_milestone_item_open_issue"
+            style="@style/Subtitle2"
+            android:layout_width="wrap_content"
+            android:layout_height="32dp"
+            android:layout_marginTop="16dp"
+            android:background="@drawable/btn_skyblue_radius"
+            android:drawableStart="@drawable/ic_issue_blue"
+            android:drawablePadding="6dp"
+            android:paddingHorizontal="15dp"
+            opeIssueCount="@{milestone.openIssueCount}"
+            android:textColor="@color/blue2"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_milestone_item_complete_day" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            style="@style/Subtitle2"
+            android:layout_width="wrap_content"
+            android:layout_height="32dp"
+            android:layout_marginTop="16dp"
+            android:background="@drawable/btn_blue_radius"
+            android:drawableStart="@drawable/ic_close_blue"
+            android:drawablePadding="6dp"
+            android:paddingHorizontal="16dp"
+            android:layout_marginStart="8dp"
+            closedIssueCount="@{milestone.closeIssueCount}"
+            android:textColor="@color/blue1"
+            app:layout_constraintStart_toEndOf="@id/btn_milestone_item_open_issue"
+            app:layout_constraintTop_toBottomOf="@id/tv_milestone_item_complete_day" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            app:layout_constraintTop_toBottomOf="@id/btn_milestone_item_open_issue"
+            android:layout_marginVertical="16dp"
+            android:background="@color/grey5" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/Android/app/src/main/res/navigation/navigation_main.xml
+++ b/Android/app/src/main/res/navigation/navigation_main.xml
@@ -25,5 +25,14 @@
         android:id="@+id/navigation_milestone"
         android:name="com.example.issue_tracker.ui.milestone.MileStoneFragment"
         android:label="fragment_mile_stone"
-        tools:layout="@layout/fragment_mile_stone" />
+        tools:layout="@layout/fragment_mile_stone" >
+        <action
+            android:id="@+id/action_navigation_milestone_to_mileStoneWriteFragment"
+            app:destination="@id/mileStoneWriteFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/mileStoneWriteFragment"
+        android:name="com.example.issue_tracker.ui.milestone.MileStoneWriteFragment"
+        android:label="fragment_mile_stone_write"
+        tools:layout="@layout/fragment_mile_stone_write" />
 </navigation>

--- a/Android/app/src/main/res/values-v23/themes.xml
+++ b/Android/app/src/main/res/values-v23/themes.xml
@@ -15,4 +15,19 @@
         <item name="android:windowLightStatusBar">true</item>
         <!-- Customize your theme here. -->
     </style>
+
+    <style name="Theme.Issue_tracker.Dark" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <!-- Primary brand color. -->
+        <item name="colorPrimary">@color/purple_500</item>
+        <item name="colorPrimaryVariant">@color/purple_700</item>
+        <item name="colorOnPrimary">@color/white</item>
+        <!-- Secondary brand color. -->
+        <item name="colorSecondary">@color/teal_200</item>
+        <item name="colorSecondaryVariant">@color/teal_700</item>
+        <item name="colorOnSecondary">@color/black</item>
+        <!-- Status bar color. -->
+        <item name="android:statusBarColor" tools:targetApi="l">@color/white</item>
+        <item name="android:windowLightStatusBar">true</item>
+        <!-- Customize your theme here. -->
+    </style>
 </resources>

--- a/Android/app/src/main/res/values/colors.xml
+++ b/Android/app/src/main/res/values/colors.xml
@@ -10,6 +10,7 @@
     <color name="skyBlue">#FF007AFF</color>
     <color name="blue1">#FF0025E7</color>
     <color name="blue2">#FF004DE3</color>
+    <color name="blue3">#FFCCD4FF</color>
     <color name="light_skyBlue">#FFCCD4FF</color>
     <color name="selected_skyBlue">#FFC7EBFF</color>
     <color name="greyScale">#FFE5E5EA</color>

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -11,4 +11,13 @@
     <string name="tool_bar_title">이슈</string>
     <string name="appbar_filter_icon">appBar_filter_icon</string>
     <string name="appbar_search_icon">appBar_search_icon</string>
+    <string name="label_milestone_item_title">제목</string>
+    <string name="label_milestone_item_progress">진행률%</string>
+    <string name="label_milestone_item_content">마일스톤에 대한 설명 (생략가능) (최대한줄)</string>
+    <string name="label_milestone_item_complete_day">완료일(생략가능)</string>
+    <string name="label_milestone_item_open_issue">열린 이슈</string>
+    <string name="label_milestone_item_close_issue">닫힌 이슈</string>
+    <string name="milestone_item_open_issue_count">열린 이슈 %d개</string>
+    <string name="milestone_item_close_issue_count">닫힌 이슈 %d개</string>
+    <string name="milestone_item_progress">%d 퍼센트</string>
 </resources>

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -20,4 +20,14 @@
     <string name="milestone_item_open_issue_count">열린 이슈 %d개</string>
     <string name="milestone_item_close_issue_count">닫힌 이슈 %d개</string>
     <string name="milestone_item_progress">%d 퍼센트</string>
+
+    <string name="milestone_write_title">새로운 마일스톤</string>
+    <string name="milestone_write_save_title">저장</string>
+    <string name="milestone_write_complete_day_hint">선택 사항(YYYY-MM-DD)</string>
+    <string name="milestone_write_complete_day_title">완료일</string>
+    <string name="milestone_write_content_hint">선택 사항</string>
+    <string name="milestone_write_content_title">설명</string>
+    <string name="milestone_write_title_hint">필수 입력</string>
+    <string name="milestone_write_title_title">제목</string>
+    <string name="milestone_write_compleday_error">잘못된 입력양식</string>
 </resources>

--- a/Android/app/src/main/res/values/styles.xml
+++ b/Android/app/src/main/res/values/styles.xml
@@ -32,6 +32,10 @@
         <item name="android:textStyle">bold</item>
     </style>
 
+
+    <style name="HeadLine6.White">
+        <item name="android:textColor">@color/white</item>
+    </style>
     //16px
 
     <style name="Subtitle1" parent="TextAppearance.MaterialComponents.Subtitle1" />

--- a/Android/app/src/main/res/values/styles.xml
+++ b/Android/app/src/main/res/values/styles.xml
@@ -24,11 +24,33 @@
 
     <style name="HeadLine6" parent="TextAppearance.MaterialComponents.Headline6" />
 
+    <style name="HeadLine6.Black">
+        <item name="android:textColor">@color/black</item>
+    </style>
+
+    <style name="HeadLine6.Black.Bold">
+        <item name="android:textStyle">bold</item>
+    </style>
 
     //16px
 
     <style name="Subtitle1" parent="TextAppearance.MaterialComponents.Subtitle1" />
 
+    <style name="Subtitle1.Black">
+        <item name="android:textColor">@color/black</item>
+    </style>
+
+    <style name="Subtitle1.Black.Bold">
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="Subtitle1.Green">
+        <item name="android:textColor">@color/green</item>
+    </style>
+
+    <style name="Subtitle1.Green.Bold">
+        <item name="android:textStyle">bold</item>
+    </style>
     //14px
 
     <style name="Subtitle2" parent="TextAppearance.MaterialComponents.Subtitle2" />

--- a/Android/app/src/main/res/values/themes.xml
+++ b/Android/app/src/main/res/values/themes.xml
@@ -11,7 +11,6 @@
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
         <item name="android:statusBarColor" tools:targetApi="l">@color/white</item>
-        <item name="android:windowLightStatusBar">true</item>
         <!-- Customize your theme here. -->
     </style>
 </resources>


### PR DESCRIPTION
## Issue
- close #14  #13 

## OverView
- 마일스톤 페이지 UI 구성 완료
- 마일스톤 모델 추가
- 마일스톤 페이지 바인딩 어댑터를 통해 데이터를 UI에 표시
- 바텀 내비게이션 라벨 표시 수정
- 바텀 내비게이션 selector 정의, 추가
- 마일스톤 더미데이터로 테스트
- 마일스톤 작성 페이지 UI 구성 완료
- 완료일 입력값에 대한 Validation 체크 추가
- 제목 입력값에 대한 Validation 체크 추가
- 제목 입력값에 대한 flag를 통해 저장기능 활성화/비활성화