### PR TITLE
[Android][히데]  이슈 작성 페이지 UI,  마크다운 변경,  팝업 윈도우 구현

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -45,7 +45,6 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.2'
     implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.1'

--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -57,4 +57,8 @@ dependencies {
     implementation 'androidx.navigation:navigation-fragment-ktx:2.4.2'
     implementation 'androidx.navigation:navigation-ui-ktx:2.4.2'
 
+    implementation "io.noties.markwon:core:4.2.0"
+    implementation "io.noties.markwon:image:4.2.0"
+
+
 }

--- a/Android/app/src/main/AndroidManifest.xml
+++ b/Android/app/src/main/AndroidManifest.xml
@@ -11,15 +11,17 @@
         android:theme="@style/Theme.Issue_tracker">
         <activity
             android:name=".ui.login.LogInActivity"
-            android:exported="false" />
-        <activity
-            android:name=".MainActivity"
             android:exported="true">
+
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
         </activity>
     </application>
 

--- a/Android/app/src/main/AndroidManifest.xml
+++ b/Android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     package="com.example.issue_tracker">
 
     <uses-permission android:name="android.permission.INTERNET"/>
-
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -25,8 +25,6 @@
         <activity
             android:name=".MainActivity"
             android:windowSoftInputMode="adjustPan"
-
-
             android:exported="true">
         </activity>
     </application>

--- a/Android/app/src/main/AndroidManifest.xml
+++ b/Android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.issue_tracker">
 
+    <uses-permission android:name="android.permission.INTERNET"/>
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -11,6 +13,7 @@
         android:theme="@style/Theme.Issue_tracker">
         <activity
             android:name=".ui.login.LogInActivity"
+            android:windowSoftInputMode="adjustPan"
             android:exported="true">
 
             <intent-filter>
@@ -21,6 +24,9 @@
         </activity>
         <activity
             android:name=".MainActivity"
+            android:windowSoftInputMode="adjustPan"
+
+
             android:exported="true">
         </activity>
     </application>

--- a/Android/app/src/main/java/com/example/issue_tracker/MainActivity.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/MainActivity.kt
@@ -31,6 +31,7 @@ class MainActivity : AppCompatActivity() {
         navController?.addOnDestinationChangedListener { _, destination, _ ->
             when (destination.id) {
                 R.id.mileStoneWriteFragment -> binding.bottomNavigationView.menu[2].isChecked = true
+                R.id.labelWriteFragment-> binding.bottomNavigationView.menu[1].isChecked= true
             }
         }
     }

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/common/IssueCountAdapter.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/common/IssueCountAdapter.kt
@@ -17,5 +17,5 @@ fun setOpenIssueCount(view: TextView, openIssueCount: Int) {
 
 @BindingAdapter("closedIssueCount")
 fun setClosedIssueCount(view: TextView, closedIssueCount: Int) {
-    view.text = view.context.getString(R.string.milestone_item_open_issue_count, closedIssueCount)
+    view.text = view.context.getString(R.string.milestone_item_close_issue_count, closedIssueCount)
 }

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/issue/home/IssueHomeFragment.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/issue/home/IssueHomeFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
+import androidx.navigation.NavController
 import androidx.navigation.Navigation
 import com.example.issue_tracker.R
 import com.example.issue_tracker.databinding.FragmentIssueHomeBinding
@@ -14,6 +15,7 @@ import com.example.issue_tracker.databinding.FragmentIssueHomeBinding
 class IssueHomeFragment : Fragment() {
 
     private lateinit var binding: FragmentIssueHomeBinding
+    private lateinit var navigator:NavController
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -25,6 +27,7 @@ class IssueHomeFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        navigator= Navigation.findNavController(view)
         val tempList = listOf<Issue>(
             Issue("마일스톤", "제목", "설명", "label"),
             Issue("마스터즈 코스1", "이슈트래커1", "6월 13일에서 20일까지", "ABCDEF"),
@@ -34,6 +37,10 @@ class IssueHomeFragment : Fragment() {
         val adapter = IssueAdapter()
         binding.rvIssue.adapter = adapter
         adapter.submitList(tempList)
+
+        binding.btnFilter.setOnClickListener {
+            navigator.navigate(R.id.action_navigation_issue_to_issueWriteFragment)
+        }
     }
 
 }

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/issue/write/IssueWriteFragment.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/issue/write/IssueWriteFragment.kt
@@ -1,0 +1,82 @@
+package com.example.issue_tracker.ui.issue.write
+
+import android.app.ActionBar
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.PopupWindow
+import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.Fragment
+import com.example.issue_tracker.R
+import com.example.issue_tracker.databinding.FragmentIssueWriteBinding
+import io.noties.markwon.Markwon
+import io.noties.markwon.image.ImagesPlugin
+
+
+class IssueWriteFragment : Fragment() {
+    private var markDownFlag = false
+    private var beforeChangedText = ""
+    private lateinit var binding: FragmentIssueWriteBinding
+    private lateinit var markOne: Markwon
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_issue_write, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        markOne = Markwon.builder(requireContext()).usePlugin(ImagesPlugin.create()).build()
+        displayMarkDownPreview()
+        binding.etIssueWriteContent.setOnClickListener {
+
+            displayPopup(view)
+        }
+
+    }
+
+
+    private fun displayPopup(view: View){
+        val popupWindow= PopupWindow(view, LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT)
+        println("call Here")
+        val inflater= requireContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
+        val popupView= inflater.inflate(R.layout.issue_popup_window, null)
+        popupWindow.contentView= popupView
+        popupWindow.isTouchable= true
+        popupWindow.isFocusable=true
+        popupWindow.isOutsideTouchable=true
+        popupWindow.showAsDropDown(view)
+    }
+
+    private fun displayMarkDownPreview() {
+        binding.tvIssuePreviewTitle.setOnClickListener {
+            if (!markDownFlag) {
+                switchToMarkDownView()
+            } else {
+                switchToEditTextView()
+            }
+        }
+    }
+
+    private fun switchToMarkDownView() {
+        beforeChangedText = binding.etIssueWriteContent.text.toString()
+        binding.etIssueWriteContent.isFocusable = false
+        markOne.setMarkdown(
+            binding.etIssueWriteContent,
+            binding.etIssueWriteContent.text.toString()
+        )
+        markDownFlag = true
+    }
+
+    private fun switchToEditTextView() {
+        binding.etIssueWriteContent.setText(beforeChangedText)
+        binding.etIssueWriteContent.isFocusable = true
+        beforeChangedText = ""
+        markDownFlag = false
+    }
+}

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/issue/write/IssueWriteFragment.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/issue/write/IssueWriteFragment.kt
@@ -1,11 +1,12 @@
 package com.example.issue_tracker.ui.issue.write
 
-import android.app.ActionBar
 import android.content.Context
 import android.os.Bundle
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.PopupWindow
 import androidx.databinding.DataBindingUtil
@@ -18,7 +19,13 @@ import io.noties.markwon.image.ImagesPlugin
 
 class IssueWriteFragment : Fragment() {
     private var markDownFlag = false
+    private lateinit var popupWindow: PopupWindow
     private var beforeChangedText = ""
+    private var copyText=""
+    private lateinit var cutButton:Button
+    private lateinit var copyButton:Button
+    private lateinit var insertPhotoButton:Button
+    private lateinit var pasteButton:Button
     private lateinit var binding: FragmentIssueWriteBinding
     private lateinit var markOne: Markwon
     override fun onCreateView(
@@ -33,24 +40,61 @@ class IssueWriteFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         markOne = Markwon.builder(requireContext()).usePlugin(ImagesPlugin.create()).build()
         displayMarkDownPreview()
-        binding.etIssueWriteContent.setOnClickListener {
+        setLongClickPopupWindow(view)
 
+    }
+
+    private fun setLongClickPopupWindow(view: View) {
+        binding.etIssueWriteContent.setOnLongClickListener {
             displayPopup(view)
+            true
+        }
+    }
+
+    private fun addCutAction(){
+        cutButton.setOnClickListener {
+            copyText= binding.etIssueWriteContent.text.toString()
+            binding.etIssueWriteContent.setText("")
         }
 
     }
 
+    private fun addCopyAction(){
+        copyButton.setOnClickListener {
+            copyText= binding.etIssueWriteContent.text.toString()
+        }
+    }
 
-    private fun displayPopup(view: View){
-        val popupWindow= PopupWindow(view, LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT)
-        println("call Here")
-        val inflater= requireContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
-        val popupView= inflater.inflate(R.layout.issue_popup_window, null)
-        popupWindow.contentView= popupView
-        popupWindow.isTouchable= true
-        popupWindow.isFocusable=true
-        popupWindow.isOutsideTouchable=true
-        popupWindow.showAsDropDown(view)
+    private fun addPasteAction(){
+        pasteButton.setOnClickListener {
+            binding.etIssueWriteContent.append(copyText)
+        }
+    }
+
+    private fun displayPopup(view: View) {
+        popupWindow = PopupWindow(view, LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT)
+        val inflater = requireContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
+        val popupView = inflater.inflate(R.layout.issue_popup_window, null)
+        findMenuButton(popupView)
+        addMenuEventListener()
+        popupWindow.contentView = popupView
+        popupWindow.isTouchable = true
+        popupWindow.isFocusable = true
+        popupWindow.isOutsideTouchable = true
+        popupWindow.showAtLocation(view, Gravity.CENTER, 0, -200);
+    }
+
+    private fun findMenuButton(popupView:View){
+        copyButton= popupView.findViewById(R.id.btn_copy)
+        cutButton= popupView.findViewById(R.id.btn_cut)
+        insertPhotoButton= popupView.findViewById(R.id.btn_insert_photo)
+        pasteButton = popupView.findViewById(R.id.btn_paste)
+    }
+
+    private fun addMenuEventListener(){
+        addCopyAction()
+        addCutAction()
+        addPasteAction()
     }
 
     private fun displayMarkDownPreview() {

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/issue/write/IssueWriteFragment.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/issue/write/IssueWriteFragment.kt
@@ -1,7 +1,14 @@
 package com.example.issue_tracker.ui.issue.write
 
+import android.Manifest
+import android.app.Activity.RESULT_OK
 import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Bundle
+import android.provider.MediaStore
+import android.provider.Settings
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
@@ -9,23 +16,31 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.PopupWindow
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AlertDialog
+import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import com.example.issue_tracker.R
 import com.example.issue_tracker.databinding.FragmentIssueWriteBinding
+import com.google.android.material.snackbar.Snackbar
+import io.noties.markwon.AbstractMarkwonPlugin
 import io.noties.markwon.Markwon
+import io.noties.markwon.MarkwonPlugin
 import io.noties.markwon.image.ImagesPlugin
+import io.noties.markwon.image.file.FileSchemeHandler
 
 
 class IssueWriteFragment : Fragment() {
     private var markDownFlag = false
     private lateinit var popupWindow: PopupWindow
     private var beforeChangedText = ""
-    private var copyText=""
-    private lateinit var cutButton:Button
-    private lateinit var copyButton:Button
-    private lateinit var insertPhotoButton:Button
-    private lateinit var pasteButton:Button
+    private var copyText = ""
+    private lateinit var cutButton: Button
+    private lateinit var copyButton: Button
+    private lateinit var insertPhotoButton: Button
+    private lateinit var pasteButton: Button
     private lateinit var binding: FragmentIssueWriteBinding
     private lateinit var markOne: Markwon
     override fun onCreateView(
@@ -38,7 +53,13 @@ class IssueWriteFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        markOne = Markwon.builder(requireContext()).usePlugin(ImagesPlugin.create()).build()
+        markOne = Markwon.builder(requireContext())
+            .usePlugin(ImagesPlugin.create())
+            .usePlugin(object : AbstractMarkwonPlugin() {
+                override fun configure(registry: MarkwonPlugin.Registry) {
+                    registry.require(ImagesPlugin::class.java) { imagesPlugin -> imagesPlugin.addSchemeHandler(FileSchemeHandler.create()) }
+                }
+            }).build()
         displayMarkDownPreview()
         setLongClickPopupWindow(view)
 
@@ -51,21 +72,21 @@ class IssueWriteFragment : Fragment() {
         }
     }
 
-    private fun addCutAction(){
+    private fun addCutAction() {
         cutButton.setOnClickListener {
-            copyText= binding.etIssueWriteContent.text.toString()
+            copyText = binding.etIssueWriteContent.text.toString()
             binding.etIssueWriteContent.setText("")
         }
 
     }
 
-    private fun addCopyAction(){
+    private fun addCopyAction() {
         copyButton.setOnClickListener {
-            copyText= binding.etIssueWriteContent.text.toString()
+            copyText = binding.etIssueWriteContent.text.toString()
         }
     }
 
-    private fun addPasteAction(){
+    private fun addPasteAction() {
         pasteButton.setOnClickListener {
             binding.etIssueWriteContent.append(copyText)
         }
@@ -84,17 +105,28 @@ class IssueWriteFragment : Fragment() {
         popupWindow.showAtLocation(view, Gravity.CENTER, 0, -200);
     }
 
-    private fun findMenuButton(popupView:View){
-        copyButton= popupView.findViewById(R.id.btn_copy)
-        cutButton= popupView.findViewById(R.id.btn_cut)
-        insertPhotoButton= popupView.findViewById(R.id.btn_insert_photo)
+    private fun findMenuButton(popupView: View) {
+        copyButton = popupView.findViewById(R.id.btn_copy)
+        cutButton = popupView.findViewById(R.id.btn_cut)
+        insertPhotoButton = popupView.findViewById(R.id.btn_insert_photo)
         pasteButton = popupView.findViewById(R.id.btn_paste)
     }
 
-    private fun addMenuEventListener(){
+    private fun addMenuEventListener() {
         addCopyAction()
         addCutAction()
         addPasteAction()
+        addInsertPhotoEventListener()
+    }
+
+    private fun addInsertPhotoEventListener() {
+        insertPhotoButton.setOnClickListener {
+            if (isAllPermissionsGranted()) {
+                getPhotoFromGallery()
+            } else {
+                requestPermissionLauncher.launch(REQUIRED_PERMISSIONS)
+            }
+        }
     }
 
     private fun displayMarkDownPreview() {
@@ -122,5 +154,109 @@ class IssueWriteFragment : Fragment() {
         binding.etIssueWriteContent.isFocusable = true
         beforeChangedText = ""
         markDownFlag = false
+    }
+
+    private val requestPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
+            permissions.entries.forEach { permission ->
+                when {
+                    permission.value -> {
+                        Snackbar.make(binding.root, "Permission granted", Snackbar.LENGTH_SHORT)
+                            .show()
+                    }
+                    shouldShowRequestPermissionRationale(permission.key) -> {
+                        showContextPopupPermission()
+                    }
+                    else -> {
+                        Snackbar.make(binding.root, "Permission denied", Snackbar.LENGTH_SHORT)
+                            .show()
+                    }
+                }
+            }
+        }
+
+    private fun showContextPopupPermission() {
+        AlertDialog.Builder(requireContext()).setTitle("권한이 필요합니다")
+            .setMessage("사진을 불러오기 위해 권한설정이 필요합니다")
+            .setPositiveButton("설정하러가기") { _, _ ->
+                val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                    .setData(Uri.parse("package:${requireContext().packageName}"))
+                startActivity(intent)
+            }
+            .setNegativeButton("취소하기") { _, _ -> }
+            .create()
+            .show()
+
+    }
+
+    private fun isAllPermissionsGranted(): Boolean = REQUIRED_PERMISSIONS.all { permission ->
+        ContextCompat.checkSelfPermission(
+            this.requireContext(),
+            permission
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun getPhotoFromGallery() {
+        val intent = Intent()
+        intent.type = "image/*"
+        intent.action = Intent.ACTION_GET_CONTENT
+        getPhoto.launch(intent)
+    }
+
+    private val getPhoto: ActivityResultLauncher<Intent> =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            if (it.resultCode == RESULT_OK && it.data != null) {
+                val currentImageUri = it.data?.data
+                println(currentImageUri)
+                try {
+                    currentImageUri?.let {uri->
+                        binding.etIssueWriteContent.append(
+                            "![alt](file://${getFullPathFromUri(requireContext(), uri)})"
+                        )
+                    }
+
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                }
+            }
+        }
+
+
+    private fun getFullPathFromUri(ctx: Context, fileUri: Uri): String? {
+        var fullPath: String? = null
+        val column = "_data"
+        var cursor = ctx.contentResolver.query(fileUri, null, null, null, null)
+        if (cursor != null) {
+            cursor.moveToFirst()
+            var documentId = cursor.getString(0)
+            if (documentId == null) {
+                for (i in 0 until cursor.columnCount) {
+                    if (column.equals(cursor.getColumnName(i), ignoreCase = true)) {
+                        fullPath = cursor.getString(i)
+                        break
+                    }
+                }
+            } else {
+                documentId = documentId.substring(documentId.lastIndexOf(":") + 1)
+                cursor.close()
+                val projection = arrayOf(column)
+                try {
+                    cursor = ctx.contentResolver.query(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, projection, MediaStore.Images.Media._ID + " = ? ", arrayOf(documentId), null)
+                    if (cursor != null) {
+                        cursor.moveToFirst()
+                        fullPath = cursor.getString(cursor.getColumnIndexOrThrow(column))
+                    }
+                } finally {
+                    cursor.close()
+                }
+            }
+        }
+        return fullPath
+    }
+
+    companion object {
+        private val REQUIRED_PERMISSIONS = arrayOf(
+            Manifest.permission.READ_EXTERNAL_STORAGE
+        )
     }
 }

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/label/LabelWriteFragment.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/label/LabelWriteFragment.kt
@@ -1,12 +1,16 @@
 package com.example.issue_tracker.ui.label
 
 import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
+import androidx.navigation.NavController
+import androidx.navigation.Navigation
 import com.example.issue_tracker.R
 import com.example.issue_tracker.databinding.FragmentLabelWriteBinding
 import kotlin.random.Random
@@ -15,7 +19,9 @@ import kotlin.random.Random
 class LabelWriteFragment : Fragment() {
 
     private lateinit var binding: FragmentLabelWriteBinding
-
+    private var titleFlag = false
+    private var colorFlag = false
+    private lateinit var navigator: NavController
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -26,41 +32,101 @@ class LabelWriteFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        navigator= Navigation.findNavController(view)
         initColor()
         changeStatusBarColor()
         refreshColor()
+        validateLabelTitle()
+        validateLabelColor()
+        setUpBackButton()
     }
 
-    private fun initColor(){
-        binding.labelRandomColor=getString(R.string.label_write_base_color).toLong(16).toInt()
+    private fun initColor() {
+        binding.labelRandomColor = getString(R.string.label_write_base_color).toLong(16).toInt()
     }
 
-    private fun refreshColor(){
+    private fun refreshColor() {
         binding.iBtnLabelWriteColorRefresh.setOnClickListener {
-            val colorString= setupRandomColor()
+            val colorString = setupRandomColor()
             binding.etLabelWriteColor.setText("#${colorString}")
-            binding.labelRandomColor= ("FF${colorString}".toLong(16).toInt())
+            binding.labelRandomColor = ("FF${colorString}".toLong(16).toInt())
         }
     }
 
-    private fun setupRandomColor():String{
-        val redValue= Random.nextInt(256).toString(16)
-        val greenValue= Random.nextInt(256).toString(16)
+    private fun setupRandomColor(): String {
+        val redValue = Random.nextInt(256).toString(16)
+        val greenValue = Random.nextInt(256).toString(16)
         val blueValue = Random.nextInt(256).toString(16)
         return "${checkHexLength(redValue)}${checkHexLength(greenValue)}${checkHexLength(blueValue)}"
     }
 
-    private fun checkHexLength(RGBValue:String):String{
-        return if(RGBValue.length<2){
+    private fun checkHexLength(RGBValue: String): String {
+        return if (RGBValue.length < 2) {
             "0${RGBValue}"
-        } else{
+        } else {
             RGBValue
+        }
+    }
+
+    private fun validateLabelColor() {
+        binding.etLabelWriteColor.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+
+            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+
+            override fun afterTextChanged(inputColor: Editable?) {
+                val title = inputColor.toString()
+                colorFlag= title.isNotEmpty()
+                setSaveTitleColor()
+            }
+        }
+        )
+    }
+
+
+    private fun validateLabelTitle() {
+        binding.etLabelWriteTitle.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+
+            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+
+            override fun afterTextChanged(inputTitle: Editable?) {
+                val title = inputTitle.toString()
+                titleFlag = title.isNotEmpty()
+                setSaveTitleColor()
+            }
+        }
+        )
+    }
+
+    private fun setSaveTitleColor() {
+        if (titleFlag&&colorFlag) {
+            binding.etLabelWriteColor.error = null
+            binding.tvLabelWriteSaveTitle.setTextColor(ContextCompat.getColor(requireContext(), R.color.white))
+        }
+        else if(!titleFlag&&colorFlag){
+            binding.etLabelWriteColor.error = null
+            binding.etLabelWriteTitle.error = "필수입력값입니다"
+            binding.tvLabelWriteSaveTitle.setTextColor(ContextCompat.getColor(requireContext(), R.color.grey1))
+        }
+        else  if(!colorFlag&&titleFlag){
+            binding.etLabelWriteColor.error = "필수입력값입니다"
+            binding.tvLabelWriteSaveTitle.setTextColor(ContextCompat.getColor(requireContext(), R.color.grey1))
+        }
+        else{
+            binding.tvLabelWriteSaveTitle.setTextColor(ContextCompat.getColor(requireContext(), R.color.grey1))
         }
     }
 
     private fun changeStatusBarColor() {
         requireActivity().window.statusBarColor =
             ContextCompat.getColor(requireContext(), R.color.skyBlue)
+    }
+
+    private fun setUpBackButton() {
+        binding.iBtnLabelWriteBack.setOnClickListener {
+            navigator.navigateUp()
+        }
     }
 
     override fun onStop() {

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/login/LogInActivity.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/login/LogInActivity.kt
@@ -1,12 +1,26 @@
 package com.example.issue_tracker.ui.login
 
+import android.content.Intent
+import android.database.DatabaseUtils
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.databinding.DataBindingUtil
+import com.example.issue_tracker.MainActivity
 import com.example.issue_tracker.R
+import com.example.issue_tracker.databinding.ActivityLogInBinding
 
 class LogInActivity : AppCompatActivity() {
+
+    private lateinit var binding:ActivityLogInBinding
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_log_in)
+
+        binding= DataBindingUtil.setContentView(this, R.layout.activity_log_in)
+        binding.lifecycleOwner= this
+
+        binding.tvLoginBtnTitle.setOnClickListener {
+            val intent= Intent(this, MainActivity::class.java)
+            startActivity(intent)
+        }
     }
 }

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/milestone/MileStoneFragment.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/milestone/MileStoneFragment.kt
@@ -30,9 +30,6 @@ class MileStoneFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         adapter = MilestoneAdapter()
         navigator = Navigation.findNavController(view)
-        var window = requireActivity().window
-
-        //window.statusBarColor= ContextCompat.getColor(requireContext(), R.color.skyBlue)
         binding.iBtnMilestoneAdd.setOnClickListener {
             moveToAddMileStone()
         }

--- a/Android/app/src/main/res/drawable/btn_black_center.xml
+++ b/Android/app/src/main/res/drawable/btn_black_center.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/DarkGrey"/>
+    <stroke android:width="1dp" android:color="@color/white" />
+
+
+</shape>

--- a/Android/app/src/main/res/drawable/btn_black_left_radius.xml
+++ b/Android/app/src/main/res/drawable/btn_black_left_radius.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/DarkGrey"/>
+    <stroke android:width="1dp" android:color="@color/white" />
+    <corners android:topLeftRadius="60dp" android:bottomLeftRadius="60dp"/>
+
+</shape>

--- a/Android/app/src/main/res/drawable/btn_black_right_radius.xml
+++ b/Android/app/src/main/res/drawable/btn_black_right_radius.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/DarkGrey"/>
+    <stroke android:width="1dp" android:color="@color/white" />
+    <corners android:topRightRadius="60dp" android:bottomRightRadius="60dp"/>
+
+</shape>

--- a/Android/app/src/main/res/layout/activity_log_in.xml
+++ b/Android/app/src/main/res/layout/activity_log_in.xml
@@ -1,117 +1,122 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:paddingHorizontal="16dp"
-    tools:context=".ui.login.LogInActivity">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <TextView
-        android:id="@+id/tv_login_title"
-        style="@style/HeadLine3.Black.Italic"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="84dp"
-        android:text="Issue Tracker"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    <data>
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/etl_login_id"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="60dp"
-        android:hint="@string/label_login_id_hint"
-        app:hintTextAppearance="@style/Caption.Grey"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_login_title"
-        app:placeholderText="@string/label_login_id_placeholder">
+    </data>
 
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/et_login_id"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:focusable="true"
-            android:inputType="textEmailAddress"
-            android:textAppearance="@style/Subtitle2" />
-
-    </com.google.android.material.textfield.TextInputLayout>
-
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/etl_login_pwd"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:hint="@string/label_login_pwd_hint"
-        app:hintTextAppearance="@style/Caption.Grey"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/etl_login_id"
-        app:passwordToggleEnabled="true"
-        app:placeholderText="@string/label_login_pwd_placeholder">
-
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/et_login_pwd"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:focusable="true"
-            android:inputType="textPassword"
-            android:textAppearance="@style/Subtitle2" />
-
-    </com.google.android.material.textfield.TextInputLayout>
-
-    <TextView
-        android:id="@+id/tv_login_btn_title"
-        style="@style/Subtitle2.Primary.Bold"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="99dp"
-        android:layout_marginTop="42dp"
-        android:text="@string/label_string_login_title"
-        app:layout_constraintStart_toStartOf="@id/etl_login_pwd"
-        app:layout_constraintTop_toBottomOf="@id/etl_login_pwd" />
-
-    <TextView
-        android:id="@+id/tv_register_btn_title"
-        style="@style/Subtitle2.Primary.Bold"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="96dp"
-        android:layout_marginTop="42dp"
-        android:text="@string/label_string_register_title"
-        app:layout_constraintStart_toEndOf="@id/tv_login_btn_title"
-        app:layout_constraintTop_toBottomOf="@id/etl_login_pwd" />
-
-    <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/btn_github_login"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@id/tv_register_btn_title"
-        android:background="@drawable/btn_black_radius"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:paddingHorizontal="16dp"
-        android:layout_marginTop="90dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:text="@string/label_string_github_login_title"
-        android:drawableStart="@drawable/ic_github_login"
-        android:textColor="@color/white"
-        />
+        tools:context=".ui.login.LogInActivity">
 
-    <androidx.appcompat.widget.AppCompatButton
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@id/btn_github_login"
-        android:background="@drawable/btn_black_radius"
-        android:paddingHorizontal="16dp"
-        android:layout_marginTop="16dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:text="@string/label_string_google_login_title"
-        android:drawableStart="@drawable/ic_google_login"
-        android:textColor="@color/white"
-        />
+        <TextView
+            android:id="@+id/tv_login_title"
+            style="@style/HeadLine3.Black.Italic"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="84dp"
+            android:text="Issue Tracker"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/etl_login_id"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="60dp"
+            android:hint="@string/label_login_id_hint"
+            app:hintTextAppearance="@style/Caption.Grey"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_login_title"
+            app:placeholderText="@string/label_login_id_placeholder">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/et_login_id"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:focusable="true"
+                android:inputType="textEmailAddress"
+                android:textAppearance="@style/Subtitle2" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/etl_login_pwd"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:hint="@string/label_login_pwd_hint"
+            app:hintTextAppearance="@style/Caption.Grey"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/etl_login_id"
+            app:passwordToggleEnabled="true"
+            app:placeholderText="@string/label_login_pwd_placeholder">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/et_login_pwd"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:focusable="true"
+                android:inputType="textPassword"
+                android:textAppearance="@style/Subtitle2" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <TextView
+            android:id="@+id/tv_login_btn_title"
+            style="@style/Subtitle2.Primary.Bold"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="99dp"
+            android:layout_marginTop="42dp"
+            android:text="@string/label_string_login_title"
+            app:layout_constraintStart_toStartOf="@id/etl_login_pwd"
+            app:layout_constraintTop_toBottomOf="@id/etl_login_pwd" />
+
+        <TextView
+            android:id="@+id/tv_register_btn_title"
+            style="@style/Subtitle2.Primary.Bold"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="96dp"
+            android:layout_marginTop="42dp"
+            android:text="@string/label_string_register_title"
+            app:layout_constraintStart_toEndOf="@id/tv_login_btn_title"
+            app:layout_constraintTop_toBottomOf="@id/etl_login_pwd" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_github_login"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/tv_register_btn_title"
+            android:background="@drawable/btn_black_radius"
+            android:paddingHorizontal="16dp"
+            android:layout_marginTop="90dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:text="@string/label_string_github_login_title"
+            android:drawableStart="@drawable/ic_github_login"
+            android:textColor="@color/white" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/btn_github_login"
+            android:background="@drawable/btn_black_radius"
+            android:paddingHorizontal="16dp"
+            android:layout_marginTop="16dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:text="@string/label_string_google_login_title"
+            android:drawableStart="@drawable/ic_google_login"
+            android:textColor="@color/white" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/Android/app/src/main/res/layout/fragment_issue_write.xml
+++ b/Android/app/src/main/res/layout/fragment_issue_write.xml
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".ui.issue.write.IssueWriteFragment">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/tb_issue_write"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/skyBlue"
+            android:paddingTop="20dp"
+            android:paddingBottom="16dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageButton
+                android:id="@+id/iBtn_issue_write_back"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@color/skyBlue"
+                android:src="@drawable/ic_back_white" />
+
+            <TextView
+                android:id="@+id/tv_issue_write_title"
+                style="@style/HeadLine6.White"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="55dp"
+                android:text="@string/issue_wrtie_title" />
+
+            <TextView
+                android:id="@+id/tv_issue_preview_title"
+                style="@style/Subtitle2.White"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginStart="100dp"
+                android:text="@string/issue_write_preview_title" />
+
+            <TextView
+                android:id="@+id/tv_issue_write_save_title"
+                style="@style/Subtitle2.Grey"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:layout_marginEnd="20dp"
+                android:text="@string/milestone_write_save_title" />
+
+        </androidx.appcompat.widget.Toolbar>
+
+        <ScrollView
+            android:id="@+id/scroll_issue_write_content"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toTopOf="@id/cl_issue_write_tags"
+            app:layout_constraintTop_toBottomOf="@id/tb_issue_write">
+
+
+            <EditText
+                android:id="@+id/et_issue_write_content"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@android:color/transparent"
+                />
+
+        </ScrollView>
+
+
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_issue_write_tags"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/greyScale"
+            android:paddingStart="16dp"
+            app:layout_constraintBottom_toBottomOf="parent">
+
+            <TextView
+                android:id="@+id/tv_issue_write_label_title"
+                style="@style/Subtitle2.Grey"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingVertical="16dp"
+                android:text="레이블"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/tv_issue_write_label_value"
+                style="@style/Subtitle2.Grey"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingVertical="16dp"
+                android:text="선택"
+                app:layout_constraintEnd_toStartOf="@id/spinner_issue_write_label"
+                app:layout_constraintTop_toTopOf="@id/tv_issue_write_label_title" />
+
+            <Spinner
+                android:id="@+id/spinner_issue_write_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="16dp"
+                android:text="선택"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@id/tv_issue_write_label_title" />
+
+            <TextView
+                android:id="@+id/tv_issue_write_milestone_title"
+                style="@style/Subtitle2.Grey"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingVertical="16dp"
+                android:text="마일스톤"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_issue_write_label_title" />
+
+            <TextView
+                android:id="@+id/tv_issue_write_milestone_value"
+                style="@style/Subtitle2.Grey"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingVertical="16dp"
+                android:text="선택"
+                app:layout_constraintEnd_toStartOf="@id/spinner_issue_write_milestone"
+                app:layout_constraintTop_toBottomOf="@id/tv_issue_write_label_title" />
+
+            <Spinner
+                android:id="@+id/spinner_issue_write_milestone"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="16dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_issue_write_label_title" />
+
+            <TextView
+                android:id="@+id/tv_issue_write_assignee_title"
+                style="@style/Subtitle2.Grey"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingVertical="16dp"
+                android:text="작성자"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_issue_write_milestone_title" />
+
+            <TextView
+                style="@style/Subtitle2.Grey"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingVertical="16dp"
+                android:text="선택"
+                app:layout_constraintEnd_toStartOf="@id/spinner_issue_write_assignee"
+                app:layout_constraintTop_toBottomOf="@id/tv_issue_write_milestone_title" />
+
+            <Spinner
+                android:id="@+id/spinner_issue_write_assignee"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="16dp"
+                android:text="선택"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_issue_write_milestone_title" />
+
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/Android/app/src/main/res/layout/fragment_label_write.xml
+++ b/Android/app/src/main/res/layout/fragment_label_write.xml
@@ -123,6 +123,8 @@
             android:paddingVertical="16dp"
             app:layout_constraintBottom_toBottomOf="@id/tv_label_write_content_color"
             android:maxLength="10"
+            android:focusable="false"
+            android:clickable="false"
             app:layout_constraintEnd_toStartOf="@id/iBtn_label_write_color_refresh"
             app:layout_constraintStart_toEndOf="@id/tv_label_write_content_color"
             app:layout_constraintTop_toTopOf="@id/tv_label_write_content_color"

--- a/Android/app/src/main/res/layout/issue_popup_window.xml
+++ b/Android/app/src/main/res/layout/issue_popup_window.xml
@@ -18,8 +18,15 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:background="@drawable/btn_black_center"
-
         android:text="copy" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_paste"
+        style="@style/Subtitle2.White"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/btn_black_center"
+        android:text="paste" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_insert_photo"

--- a/Android/app/src/main/res/layout/issue_popup_window.xml
+++ b/Android/app/src/main/res/layout/issue_popup_window.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal">
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_cut"
+        style="@style/Subtitle2.White"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/btn_black_left_radius"
+        android:text="cut" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_copy"
+        style="@style/Subtitle2.White"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/btn_black_center"
+
+        android:text="copy" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_insert_photo"
+        style="@style/Subtitle2.White"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/btn_black_right_radius"
+        android:text="insert Photo" />
+
+
+</LinearLayout>

--- a/Android/app/src/main/res/navigation/navigation_main.xml
+++ b/Android/app/src/main/res/navigation/navigation_main.xml
@@ -10,6 +10,9 @@
         android:name="com.example.issue_tracker.ui.issue.home.IssueHomeFragment"
         android:label="fragment_issue_home"
         tools:layout="@layout/fragment_issue_home" >
+        <action
+            android:id="@+id/action_navigation_issue_to_issueWriteFragment"
+            app:destination="@id/issueWriteFragment" />
     </fragment>
     <fragment
         android:id="@id/navigation_label"
@@ -43,4 +46,8 @@
         android:id="@+id/labelWriteFragment"
         android:name="com.example.issue_tracker.ui.label.LabelWriteFragment"
         android:label="LabelWriteFragment" />
+    <fragment
+        android:id="@+id/issueWriteFragment"
+        android:name="com.example.issue_tracker.ui.issue.write.IssueWriteFragment"
+        android:label="IssueWriteFragment" />
 </navigation>

--- a/Android/app/src/main/res/values/colors.xml
+++ b/Android/app/src/main/res/values/colors.xml
@@ -23,4 +23,5 @@
     <color name="grey6">#D9D9D9</color>
     <color name="grey7">#D5D5DB</color>
     <color name="green">#FF00A028</color>
+    <color name="DarkGrey">#1C1C1E</color>
 </resources>

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -35,7 +35,7 @@
     <string name="label_title">레이블</string>
 
     <string name="label_write_title">새로운 레이블</string>
-    <string name="label_wrtie_color_hint">#3DDCFF</string>
+    <string name="label_wrtie_color_hint">#FFFFFFFF</string>
     <string name="label_write_base_color">FFFFFFFF</string>
     <string name="item_milestone_text">마일스톤</string>
     <string name="item_title">제목</string>

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -39,5 +39,9 @@
     <string name="label_write_base_color">FFFFFFFF</string>
     <string name="item_milestone_text">마일스톤</string>
     <string name="item_title">제목</string>
+<!-- TODO: Remove or change this placeholder text -->
+    <string name="hello_blank_fragment">Hello blank fragment</string>
+    <string name="issue_write_preview_title">미리보기</string>
+    <string name="issue_wrtie_title">이슈작성</string>
 
 </resources>

--- a/Android/app/src/main/res/values/styles.xml
+++ b/Android/app/src/main/res/values/styles.xml
@@ -73,6 +73,14 @@
     <style name="Subtitle2.Primary.Bold">
         <item name="android:textStyle">bold</item>
     </style>
+
+    <style name="Subtitle2.White">
+        <item name="android:textColor">@color/white</item>
+    </style>
+
+    <style name="Subtitle2.Grey">
+        <item name="android:textColor">@color/grey2</item>
+    </style>
     //12px
 
     <style name="Caption" parent="TextAppearance.MaterialComponents.Caption"/>


### PR DESCRIPTION
## Issue
- close #23 

## OverView
- Issue Write 페이지 UI 완성
- EditText의 내용을 마크다운으로 보여주는 라이브러리 추가, 적용
- editText 중앙 상단에 팝업 윈도우가 뜨도록 조정
- 붙이기버튼은 저장되어있는 text를 editText에 append
- 복사 버튼은 editText에 현재 저장되어있는 text를 copyText에 복사
- 자르기 버튼은 editTextdㅔ 현재 저장되어 있는 text를 copyText에 복사후, 현재 editText를 비움
- 앨범 접근을 위한 권한 처리 로직 추가
- 앨범에서 불러온 uri에서 realPath 추출 함수 추가
- 마크다운으로 변경하기 위해 라이브러리에 플러그인 설정 추가