### PR TITLE
[Android][JungPark] IssueItem editMode 구현

### DIFF
--- a/Android/app/src/main/java/com/example/issue_tracker/ui/issue/home/IssueAdapter.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/issue/home/IssueAdapter.kt
@@ -1,6 +1,8 @@
 package com.example.issue_tracker.ui.issue.home
 
+import android.content.res.ColorStateList
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
@@ -8,20 +10,55 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.issue_tracker.databinding.ItemIssuesBinding
 import com.example.issue_tracker.domain.model.Issue
 
-class IssueAdapter(private val itemClick: (selectedIssueID: Int) -> Unit) :
+class IssueAdapter(
+    private val itemClick: (selectedIssueID: Int) -> Unit
+) :
     ListAdapter<Issue, IssueAdapter.ViewHolder>(IssueDiffUtil) {
+    var issueAdapterEventListener: IssueAdapterEventListener? = null
+    var isEditMode = false
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): IssueAdapter.ViewHolder {
         val inflater = LayoutInflater.from(parent.context)
-        return ViewHolder(ItemIssuesBinding.inflate(inflater, parent, false))
+        return ViewHolder(
+            ItemIssuesBinding.inflate(inflater, parent, false)
+        )
     }
 
-    inner class ViewHolder(private val binding: ItemIssuesBinding) :
-        RecyclerView.ViewHolder(binding.root) {
-        fun bind(itemIssue: Issue, itemClick: (selectedIssueID: Int) -> Unit) {
-            binding.itemIssue = itemIssue
-            binding.root.setOnClickListener {
+    inner class ViewHolder(
+        private val binding: ItemIssuesBinding
+        ) : RecyclerView.ViewHolder(binding.root)
+    {
+        fun bind(
+            itemIssue: Issue,
+            itemClick: (selectedIssueID: Int) -> Unit
+        ) {
+            if (isEditMode) {
+                binding.cbIssueSelector.visibility = View.VISIBLE
+                binding.cbIssueSelector.isChecked = false
+            } else {
+                binding.cbIssueSelector.visibility = View.GONE
+            }
+
+            binding.clSwipeView.setOnClickListener {
                 itemClick.invoke(itemIssue.id)
+            }
+            binding.itemIssue = itemIssue
+
+            binding.clSwipeView.setOnLongClickListener {
+                issueAdapterEventListener?.switchToEditMode(itemIssue.id)
+                true
+            }
+
+            binding.cbIssueSelector.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) {
+                    issueAdapterEventListener?.addInCheckList(itemIssue.id)
+                    binding.cbIssueSelector.setBackgroundColor(0xffF2F2F7.toInt())
+                    binding.cbIssueSelector.buttonTintList = ColorStateList.valueOf(0xff007AFF.toInt())
+                } else {
+                    issueAdapterEventListener?.deleteInCheckList(itemIssue.id)
+                    binding.cbIssueSelector.setBackgroundColor(0xffffffff.toInt())
+                    binding.cbIssueSelector.buttonTintList = ColorStateList.valueOf(0xffD5D5DB.toInt())
+                }
             }
         }
     }

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/issue/home/IssueAdapterEventListener.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/issue/home/IssueAdapterEventListener.kt
@@ -1,0 +1,11 @@
+package com.example.issue_tracker.ui.issue.home
+
+import com.example.issue_tracker.domain.model.Issue
+
+interface IssueAdapterEventListener {
+    fun updateIssueState(itemId: Int, boolean: Boolean)
+    fun switchToEditMode(itemId: Int)
+    fun addInCheckList(itemId: Int)
+    fun deleteInCheckList(itemId: Int)
+    fun getIntoDetail(issue: Issue)
+}

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/issue/home/IssueHomeViewModel.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/issue/home/IssueHomeViewModel.kt
@@ -10,8 +10,14 @@ class IssueHomeViewModel : ViewModel() {
     private val _stateList = MutableStateFlow<List<IssueState>>(listOf())
     val stateList: StateFlow<List<IssueState>> = _stateList
 
-    private val _issueList = MutableStateFlow<List<Issue>>(listOf())
+    private val _issueList = MutableStateFlow<MutableList<Issue>>(mutableListOf())
     val issueList: StateFlow<List<Issue>> = _issueList
+
+    private val _checkList = MutableStateFlow<MutableList<Int>>(mutableListOf())
+    val checkList: StateFlow<List<Int>> = _checkList
+
+    private val _closeIssueList = MutableStateFlow<MutableList<Issue>>(mutableListOf())
+    val closeIssueList: StateFlow<List<Issue>> = _closeIssueList
 
     init {
         initStateList()
@@ -19,14 +25,54 @@ class IssueHomeViewModel : ViewModel() {
     }
 
     private fun initStateList() {
-        _stateList.value = listOf(IssueState.OPEN, IssueState.WRITE_MYSELF, IssueState.ASSIGN_MYSELF, IssueState.WRITE_COMMENT, IssueState.CLOSE)
+        _stateList.value = listOf(
+            IssueState.OPEN,
+            IssueState.WRITE_MYSELF,
+            IssueState.ASSIGN_MYSELF,
+            IssueState.WRITE_COMMENT,
+            IssueState.CLOSE
+        )
     }
 
     private fun makeDummyIssueList() {
-        _issueList.value = listOf<Issue>(
+        _issueList.value = mutableListOf<Issue>(
             Issue(1, "마일스톤", "제목", "설명", "label"),
             Issue(2, "마스터즈 코스1", "이슈트래커1", "6월 13일에서 20일까지", "ABCDEF"),
             Issue(3, "마스터즈 코스2", "이슈트래커2", "7월 9일에서 12일까지", "asdfef")
         )
+    }
+
+    fun addCheckList(itemId: Int) {
+        _checkList.value.add(itemId)
+    }
+
+    fun removeCheckList(itemId: Int) {
+        _checkList.value.removeIf {
+            it == itemId
+        }
+    }
+
+    fun clearCheckList() {
+        _checkList.value.clear()
+    }
+
+    fun closeIssueList() {
+        for (i in 0 until _checkList.value.size) {
+            val str = _issueList.value.filter {
+                it.id == _checkList.value[i]
+            }
+            _issueList.value.removeIf {
+                it.id == checkList.value[i]
+            }
+            _closeIssueList.value.add(str[0])
+        }
+    }
+
+    fun removeIssueList() {
+        for (i in 0 until _checkList.value.size) {
+            _issueList.value.removeIf {
+                it.id == checkList.value[i]
+            }
+        }
     }
 }

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/issue/home/ItemHelper.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/issue/home/ItemHelper.kt
@@ -4,7 +4,7 @@ import android.graphics.Canvas
 import android.icu.lang.UCharacter.IndicPositionalCategory.LEFT
 import android.view.View
 import androidx.recyclerview.widget.ItemTouchHelper
-import androidx.recyclerview.widget.ItemTouchHelper.*
+import androidx.recyclerview.widget.ItemTouchHelper.ACTION_STATE_SWIPE
 import androidx.recyclerview.widget.RecyclerView
 import com.example.issue_tracker.R
 
@@ -52,13 +52,6 @@ class ItemHelper(private val issueAdapter: IssueAdapter) : ItemTouchHelper.Callb
                 isCurrentlyActive
             )  // newX 만큼 이동(고정 시 이동 위치/고정 해제 시 이동 위치 결정)
 
-            // 고정시킬 시 애니메이션 추가
-//            if (newX == -clamp) {
-//                getView(viewHolder).animate().translationX(-clamp).setDuration(100L).start()
-//                return
-//            }
-
-            currentDx = newX
             getDefaultUIUtil().onDraw(
                 c,
                 recyclerView,
@@ -74,7 +67,7 @@ class ItemHelper(private val issueAdapter: IssueAdapter) : ItemTouchHelper.Callb
     private fun getView(viewHolder: RecyclerView.ViewHolder): View =
         viewHolder.itemView.findViewById(R.id.cl_swipe_view)
 
-    private fun getTag(viewHolder: RecyclerView.ViewHolder) : Boolean =
+    private fun getTag(viewHolder: RecyclerView.ViewHolder): Boolean =
         viewHolder.itemView.tag as? Boolean ?: false
 
 
@@ -82,17 +75,14 @@ class ItemHelper(private val issueAdapter: IssueAdapter) : ItemTouchHelper.Callb
         dX: Float,
         isClamped: Boolean,
         isCurrentlyActive: Boolean
-    ) : Float {
+    ): Float {
 
-        // 고정할 수 있으면
-        val newX = if (isClamped) {
-            // 현재 swipe 중이면 swipe되는 영역 제한
-            if (isCurrentlyActive) {
-                dX - clamp
-            }
-            else -clamp
-        }
-        else dX / 4
+        val newX =
+            if (isClamped) {
+                if (isCurrentlyActive) {
+                    dX - clamp
+                } else -clamp
+            } else dX / 4
 
         return newX
     }

--- a/Android/app/src/main/res/drawable/ic_trash.xml
+++ b/Android/app/src/main/res/drawable/ic_trash.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="16.941177dp"
+    android:viewportHeight="18" android:viewportWidth="17"
+    android:width="16dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#ffffff" android:pathData="M1.7485,18V3H0.7485V1H5.7485V0H11.7485V1H16.7485V3H15.7485V18H1.7485ZM3.7485,16H13.7485V3H3.7485V16ZM5.7485,14H7.7485V5H5.7485V14ZM9.7485,14H11.7485V5H9.7485V14Z"/>
+</vector>

--- a/Android/app/src/main/res/layout/fragment_issue_home.xml
+++ b/Android/app/src/main/res/layout/fragment_issue_home.xml
@@ -4,31 +4,32 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
-
+        <variable
+            name="viewModel"
+            type="com.example.issue_tracker.ui.issue.home.IssueHomeViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        tools:context=".ui.issue.home.IssueHomeFragment">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/cl_issue_list"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            app:layout_constraintTop_toBottomOf="@id/cl_search"
             app:layout_constraintBottom_toBottomOf="parent"
-            tools:context=".ui.issue.home.IssueHomeFragment">
-
+            app:layout_constraintTop_toBottomOf="@id/cl_search">
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/rv_issue"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:layout_constraintTop_toBottomOf="@id/tb_issues"
-                app:layout_constraintStart_toStartOf="parent"
+                android:layout_marginTop="56dp"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
                 tools:listitem="@layout/item_issues" />
-
 
             <androidx.appcompat.widget.Toolbar
                 android:id="@+id/tb_issues"
@@ -235,6 +236,67 @@
                 app:layout_constraintStart_toEndOf="@id/tv_filter_mileStone_title"
                 app:layout_constraintTop_toTopOf="@id/tv_filter_mileStone_title" />
 
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_issue_edit"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/skyBlue"
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"
+            android:visibility="gone"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageButton
+                android:id="@+id/btn_issue_edit_close"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="16dp"
+                android:backgroundTint="@color/skyBlue"
+                android:padding="0dp"
+                android:src="@drawable/ic_close"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/tv_issue_count"
+                style="@style/HeadLine6.White"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="72dp"
+                android:height="24dp"
+                android:text="0"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <ImageButton
+                android:id="@+id/btn_issue_remove"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginRight="63.25dp"
+                android:backgroundTint="@color/skyBlue"
+                android:padding="0dp"
+                android:src="@drawable/ic_trash"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <ImageButton
+                android:id="@+id/btn_issue_close"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginRight="16dp"
+                android:backgroundTint="@color/skyBlue"
+                android:padding="0dp"
+                android:src="@drawable/ic_issue_close"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:tint="@color/white" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/Android/app/src/main/res/layout/item_issues.xml
+++ b/Android/app/src/main/res/layout/item_issues.xml
@@ -7,6 +7,7 @@
         <variable
             name="itemIssue"
             type="com.example.issue_tracker.domain.model.Issue" />
+
     </data>
 
     <FrameLayout
@@ -57,29 +58,18 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/cl_swipe_view"
             android:layout_width="match_parent"
-            android:background="@color/white"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:background="@color/white">
 
-            <LinearLayout
-                android:id="@+id/ll_check"
+            <CheckBox
+                android:id="@+id/cb_issue_selector"
                 android:layout_width="100dp"
-                app:layout_constraintLeft_toLeftOf="parent"
-                android:visibility="gone"
                 android:layout_height="match_parent"
-                android:layout_weight="3"
-
-                android:background="#CCD4FF"
-                android:gravity="center"
-                android:orientation="vertical">
-
-                <ImageButton
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_horizontal"
-                    android:padding="0dp"
-                    android:src="@drawable/ic_check_on" />
-
-            </LinearLayout>
+                android:checked="false"
+                android:buttonTint="#D5D5DB"
+                android:layout_gravity="center_horizontal"
+                android:visibility="visible"
+                app:layout_constraintLeft_toLeftOf="parent" />
 
             <ImageView
                 android:id="@+id/iv_issue_milestone"
@@ -88,7 +78,7 @@
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="10dp"
                 android:src="@drawable/ic_milestone"
-                app:layout_constraintLeft_toRightOf="@id/ll_check"
+                app:layout_constraintLeft_toRightOf="@id/cb_issue_selector"
                 app:layout_constraintTop_toTopOf="parent"
                 app:tint="@color/grey6" />
 
@@ -98,9 +88,9 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="36dp"
                 android:layout_marginTop="10dp"
-                android:text="@string/item_milestone_text"
+                android:text="@{itemIssue.milestone}"
                 android:textColor="@color/grey2"
-                app:layout_constraintLeft_toRightOf="@id/ll_check"
+                app:layout_constraintLeft_toRightOf="@id/cb_issue_selector"
                 app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
@@ -109,9 +99,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
-                android:text="@string/item_title"
+                android:text="@{itemIssue.title}"
                 android:textStyle="bold"
-                app:layout_constraintLeft_toRightOf="@id/ll_check"
+                app:layout_constraintLeft_toRightOf="@id/cb_issue_selector"
                 app:layout_constraintTop_toBottomOf="@id/iv_issue_milestone" />
 
             <TextView
@@ -120,10 +110,10 @@
                 android:layout_height="20dp"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="2dp"
-                android:text="description"
+                android:text="@{itemIssue.description}"
                 android:textColor="@color/grey1"
                 android:textSize="14sp"
-                app:layout_constraintLeft_toRightOf="@id/ll_check"
+                app:layout_constraintLeft_toRightOf="@id/cb_issue_selector"
                 app:layout_constraintTop_toBottomOf="@id/tv_issue_title" />
 
             <TextView
@@ -135,9 +125,9 @@
                 android:layout_marginBottom="17dp"
                 android:background="@drawable/bg_label"
                 android:gravity="center"
-                android:text="Label"
+                android:text="@{itemIssue.label}"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintLeft_toRightOf="@id/ll_check"
+                app:layout_constraintLeft_toRightOf="@id/cb_issue_selector"
                 app:layout_constraintTop_toBottomOf="@id/tv_issue_description" />
 
             <View


### PR DESCRIPTION
## Issue
- close #40 

## OverView
- 아이템 롱클릭시 Gone 되어있던 CheckBox를 Visible로 보이도록 아이템 구현
- 롱클릭시 기본ToolBar는 Gone, EditMode용 ConstraintLayout이 보이도록 구현
- checkBox를 체크할경우 뷰모델의 _checkList에서 id를 넣고 뺴는 방법으로 관리
- checkBox를 체크후 삭제버튼을 누를경우 _issueList에서 _checkList에 있는 id를 기반으로 _issueList에서 삭제
- 그후 편집모드 종료, 편집모드 재 호출시 _checkList의 리스트 .clear 하도록함
- checkBox를 체크후 클로즈 버튼을 누를경우 id를 기반으로 issueList에서 삭제하고 closeIssueList에 해당 아이템들을 넣도록 구현